### PR TITLE
[semver major] use latest arweave bundle pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arweave cost
 
-Calculates the cost of uploading files to [Arweave](https://arweave.org/)
+Calculates the cost of uploading files to [Arweave](https://arweave.org/) using [arbundles](https://github.com/Bundlr-Network/arbundles).
 
 ## Installation
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -86,8 +86,6 @@ describe('calculate', () => {
     assert(result.arweavePrice > 0, result.arweavePrice);
     assert(result.solanaPrice > 0, result.solanaPrice);
     assert(result.exchangeRate > 0, result.exchangeRate);
-    assert(result.byteCost > 0, result.byteCost);
     assert.strictEqual(result.totalBytes, fileSizes[0] + fileSizes[1]);
-    assert(result.fee > 0, result.fee);
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 const request = require('axios');
-const assert = require('assert');
 const debug = require('debug')('arweave-cost');
+
+const assert = (truthy: any, msg: string) => {
+  if (!truthy) throw new Error(msg);
+};
 
 const ARWEAVE_URL = 'https://arweave.net';
 const CONVERSION_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=solana,arweave&vs_currencies=usd';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@ const assert = (truthy: any, msg: string) => {
   if (!truthy) throw new Error(msg);
 };
 
-const ARWEAVE_URL = 'https://arweave.net';
+// arbundler uses a pricing endpoint which also accurately captures L2 fees.
+// https://node1.bundlr.network/price/{totalUploadedBytes}
+// internal fee calculation: fee(n) = bundler fee * l1_fee(1) * max(n, 2048) * network difficulty multiplier
+
+const ARWEAVE_URL = 'https://node1.bundlr.network';
 const CONVERSION_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=solana,arweave&vs_currencies=usd';
 const WINSTON_MULTIPLIER = 10 ** 12;
 


### PR DESCRIPTION
- use the latest arweave bundle pricing API
- [semver major] remove some returned fields which are no longer necessary
- Add webpack 5 compatibility 